### PR TITLE
ci: add pylint status check workflow for PRs and pushes

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,23 +1,42 @@
 name: Pylint
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  build:
+  pylint-check:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install pylint
-    - name: Analysing the code with pylint
+
+    - name: Run Pylint
       run: |
         pylint $(git ls-files '*.py')
+      continue-on-error: true
+
+    - name: Upload Pylint results
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: pylint-results-${{ matrix.python-version }}
+        path: ./pylint-report.log
+      run: |
+        pylint $(git ls-files '*.py') | tee pylint-report.log


### PR DESCRIPTION
This workflow runs Pylint checks for Python versions 3.8, 3.9, and 3.10 on every push and pull request targeting the main branch. The results are uploaded as artifacts when linting errors are found.